### PR TITLE
Improves RexReader::getTileMap() performance

### DIFF
--- a/REXReader++/RexReader.cpp
+++ b/REXReader++/RexReader.cpp
@@ -161,7 +161,7 @@ RexTileMap* RexReader::GetTileMap()
 		for (unsigned int x = 0; x < width; x++)
 			for (unsigned int y = 0; y < height; y++)
 			{
-				std::unique_ptr<RexTile> tile = make_unique<RexTile>();
+				RexTile* tile = &map->Layers[layer]->Tiles[x + (y * width)];
 				tile->CharacterCode = GetInt(filestream);
 				tile->ForegroundRed = GetChar(filestream);
 				tile->ForegroundGreen = GetChar(filestream);
@@ -169,7 +169,6 @@ RexTileMap* RexReader::GetTileMap()
 				tile->BackgroundRed = GetChar(filestream);
 				tile->BackgroundGreen = GetChar(filestream);
 				tile->BackgroundBlue = GetChar(filestream);
-				map->Layers[layer]->Tiles[x + (y * width)] = std::move(tile);
 			}
 		offset = 16 + ((10 * width * height) + 8) * (layer + 1);
 		gzseek(filestream, offset, SEEK_SET);

--- a/REXReader++/RexReader.cpp
+++ b/REXReader++/RexReader.cpp
@@ -156,19 +156,17 @@ RexTileMap* RexReader::GetTileMap()
 	int offset = 16;
 	gzseek(filestream, offset, SEEK_SET);
 
+	//A single tile is 4 bytes for the character code and 6 bytes for the colors.
+	const int bufferLen = 10;
+	Byte buffer[bufferLen];
 	for (unsigned int layer = 0; layer < layers; layer++)
 	{
 		for (unsigned int x = 0; x < width; x++)
 			for (unsigned int y = 0; y < height; y++)
 			{
 				RexTile* tile = &map->Layers[layer]->Tiles[x + (y * width)];
-				tile->CharacterCode = GetInt(filestream);
-				tile->ForegroundRed = GetChar(filestream);
-				tile->ForegroundGreen = GetChar(filestream);
-				tile->ForegroundBlue = GetChar(filestream);
-				tile->BackgroundRed = GetChar(filestream);
-				tile->BackgroundGreen = GetChar(filestream);
-				tile->BackgroundBlue = GetChar(filestream);
+				gzread(filestream, buffer, bufferLen);
+				memcpy(tile, buffer, bufferLen);
 			}
 		offset = 16 + ((10 * width * height) + 8) * (layer + 1);
 		gzseek(filestream, offset, SEEK_SET);

--- a/REXReader++/RexTile.h
+++ b/REXReader++/RexTile.h
@@ -4,12 +4,12 @@
 struct RexTile
 {
 	unsigned int CharacterCode;
-	unsigned int BackgroundRed;
-	unsigned int BackgroundGreen;
-	unsigned int BackgroundBlue;
-	unsigned int ForegroundRed;
-	unsigned int ForegroundGreen;
-	unsigned int ForegroundBlue;
+	unsigned char ForegroundRed;
+	unsigned char ForegroundGreen;
+	unsigned char ForegroundBlue;
+	unsigned char BackgroundRed;
+	unsigned char BackgroundGreen;
+	unsigned char BackgroundBlue;
 };
 
 class RexTileLayer

--- a/REXReader++/RexTile.h
+++ b/REXReader++/RexTile.h
@@ -1,7 +1,5 @@
 #pragma once
 #include <iostream>
-#include <vector>
-#include <memory>
 
 struct RexTile
 {
@@ -17,15 +15,16 @@ struct RexTile
 class RexTileLayer
 {
 public:
-	std::vector<std::unique_ptr<RexTile>> Tiles;
+	RexTile* Tiles;
 	RexTileLayer() = default;
 	RexTileLayer(int width, int height)
 	{
-		Tiles = std::vector<std::unique_ptr<RexTile>>(width * height);
+		Tiles = new RexTile[width * height];
 	}
 	~RexTileLayer()
 	{
-		Tiles.clear();
+		delete[] Tiles;
+		Tiles = NULL;
 	}
 };
 
@@ -37,19 +36,23 @@ private:
 	unsigned int layerCount;
 
 public:
-	std::vector<std::unique_ptr<RexTileLayer>> Layers;
+	RexTileLayer* Layers[4];
 
 	RexTileMap(unsigned int width, unsigned int height, unsigned int layers)
 	{
 		this->width = width;
 		this->height = height;
 		this->layerCount = layers;
-
-		Layers = std::vector<std::unique_ptr<RexTileLayer>>(this->layerCount);
 		for (unsigned int i = 0; i < layerCount; i++)
 		{
-			this->Layers[i] = std::make_unique<RexTileLayer>(width, height);
+			this->Layers[i] = new RexTileLayer(width, height);
 		}
 	}
-	~RexTileMap() = default;
+	~RexTileMap()
+	{
+		for (unsigned int i = 0; i < layerCount; i++)
+		{
+			delete(Layers[i]);
+		}
+	}
 };

--- a/REXReader++/XPText.cpp
+++ b/REXReader++/XPText.cpp
@@ -140,7 +140,7 @@ namespace sf
 			for (int x = 0; x < width; x++)
 				for (int y = 0; y < height; y++)
 				{
-					RexTile* tile = tilemap->Layers[layer]->Tiles[x + (y * width)].get();
+					RexTile* tile = &tilemap->Layers[layer]->Tiles[x + (y * width)];
 					
 					if (tile->BackgroundRed == 255 &&
 						tile->BackgroundGreen == 0 &&
@@ -179,6 +179,8 @@ namespace sf
 					vertices.append(sf::Vertex(Vector2f((x*hspace) + right,		(y*vspace) + top),		foreground, Vector2f(u2, v1)));
 					vertices.append(sf::Vertex(Vector2f((x*hspace) + right,		(y*vspace) + bottom),	foreground, Vector2f(u2, v2)));
 				}
+
+		delete(tilemap);
 
 		bounds.left = 0;
 		bounds.top = topOffset;


### PR DESCRIPTION
Great job on this library. I've found it very useful for working with REXPaint and C++.

One thing I've noticed is that RexReader::getTileMap() performs pretty slowly for large .xp files. This is important for using REXPaint files in games, where each millisecond counts.

This pull request improves performance by:
1. Switching from unique_ptrs back to raw pointers (unique_ptrs have creation overhead. It's way worse in Debug configuration.)
2. Reading the .xp file directly into the RexTile struct

Here's a performance comparison (in microseconds) between debug (D) and release (R) configurations of both versions of REXReader++:

| .xp canvas size | Current (D) | Pull Request(D) | Current (R) | Pull Request (R) |
| --- | --- | --- | --- | --- |
| 1x1 | 63 | 5 | 3 | 3 |
| 10x10 | 400 | 11 | 36 | 8 |
| 50x50 | 10661 | 209 | 460 | 135 |
| 100x100 | 43715 | 691 | 2847 | 552 |
| 500x500 | 1022 \* 10<sup>3</sup> | 18 \* 10<sup>3</sup> | 60 \* 10<sup>3</sup> | 15 \* 10<sup>3</sup> |
| 999x999 | 4113 \* 10<sup>3</sup> | 72 \* 10<sup>3</sup> | 237 \* 10<sup>3</sup> | 68 \* 10<sup>3</sup> |

As you can see, it's a lot faster. The biggest difference is for the 999x999 canvas between the debug versions. It currently takes 4 seconds (!) to create the tile map, but this pull request takes 72 milliseconds. For a more reasonable canvas size like 50x50, you can see that the pull request is about 3.5 times faster, from 460 μs to 135.
